### PR TITLE
Health-checker module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "diskusage": "^1.2.0",
         "mysql2": "^3.6.5",
         "pg": "^8.12.0",
         "redis": "^4.7.0",
@@ -4401,6 +4402,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/diskusage": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.2.0.tgz",
+      "integrity": "sha512-2u3OG3xuf5MFyzc4MctNRUKjjwK+UkovRYdD2ed/NZNZPrt0lqHnLKxGhlFVvAb4/oufIgQG3nWgwmeTbHOvXA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.2.8",
+        "nan": "^2.18.0"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4587,6 +4599,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -7621,6 +7639,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^10.4.15",
+        "@nestjs/terminus": "^11.0.0",
         "@nestjs/typeorm": "^10.0.1",
         "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
@@ -1798,6 +1799,76 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@nestjs/terminus": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.0.0.tgz",
+      "integrity": "sha512-c55LOo9YGovmQHtFUMa/vDaxGZ2cglMTZejqgHREaApt/GArTfgYYGwhRXPLq8ZwiQQlLuYB+79e9iA8mlDSLA==",
+      "license": "MIT",
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/microservices": "^10.0.0 || ^11.0.0",
+        "@nestjs/mongoose": "^11.0.0",
+        "@nestjs/sequelize": "^10.0.0 || ^11.0.0",
+        "@nestjs/typeorm": "^10.0.0 || ^11.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x || 0.2.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "10.4.15",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.15.tgz",
@@ -2849,6 +2920,15 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -3263,6 +3343,57 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -3520,6 +3651,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -3593,6 +3733,18 @@
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.10.53",
         "validator": "^13.9.0"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -9789,7 +9941,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -10282,6 +10433,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "diskusage": "^1.2.0",
     "mysql2": "^3.6.5",
     "pg": "^8.12.0",
     "redis": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.4.15",
+    "@nestjs/terminus": "^11.0.0",
     "@nestjs/typeorm": "^10.0.1",
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { LoggingModule } from './logger/logger.module';
 import { RedisModule } from './cache-handler/cache-handler.module';
+import { HealthModule } from './health/health.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { RedisModule } from './cache-handler/cache-handler.module';
     AuthModule,
     LoggingModule,
     RedisModule,
+    HealthModule,
   ],
   controllers: [],
   providers: [],

--- a/src/cache-handler/cache-handler.module.ts
+++ b/src/cache-handler/cache-handler.module.ts
@@ -15,6 +15,7 @@ import { LoggingModule } from 'src/logger/logger.module';
           host: process.env.REDIS_HOST,
           port: parseInt(process.env.REDIS_PORT || '6379', 10),
           password: process.env.REDIS_PASSWORD,
+          database: parseInt(process.env.REDIS_DATABASE || '0', 10),
         });
       },
       inject: [LoggerService],

--- a/src/cache-handler/cache-handler.module.ts
+++ b/src/cache-handler/cache-handler.module.ts
@@ -17,7 +17,7 @@ import { LoggingModule } from 'src/logger/logger.module';
           password: process.env.REDIS_PASSWORD,
         });
       },
-      inject: [LoggerService], // Mover esta línea aquí
+      inject: [LoggerService],
     },
     CacheManagerService,
   ],

--- a/src/cache-handler/clients/redisClient.ts
+++ b/src/cache-handler/clients/redisClient.ts
@@ -15,6 +15,9 @@ export class RedisClientService implements OnModuleInit, OnModuleDestroy {
   private client: RedisClientType;
   private config: RedisConfig;
   private logger;
+  private readonly MAX_RETRY_ATTEMPTS = 5;
+  private retryCount = 0;
+
 
   constructor(
     private loggerService: LoggerService,
@@ -29,32 +32,104 @@ export class RedisClientService implements OnModuleInit, OnModuleDestroy {
     this.logger = this.loggerService.getLogger();
   }
 
+ 
   async onModuleInit() {
+    await this.initializeClient();
+  }
+
+ 
+  async onModuleDestroy() {
     try {
-      this.client = createClient({
-        url: this.config.getConectionURL(),
-      });
-
-      this.client.on('error', (err) => {
-        this.logger.error('Redis Client Error:', err);
-      });
-
-      this.client.on('connect', () => {
-        this.logger.info('Redis Client Connected Successfully');
-      });
-
-      await this.client.connect();
+      await this.client?.quit();
+      this.logger.info('Redis client successfully disconnected');
     } catch (error) {
-      this.logger.error('Failed to initialize Redis client:', error);
-      throw error;
+      this.logger.error('Error while disconnecting Redis client:', error);
     }
   }
 
-  async onModuleDestroy() {
-    await this.client?.quit();
+  
+  getClient(): RedisClientType {
+    if (!this.client) {
+      throw new Error('Redis client not initialized');
+    }
+    return this.client;
   }
 
-  getClient(): RedisClientType {
-    return this.client;
+  
+  async isHealthy(): Promise<boolean> {
+    try {
+      await this.client.ping();
+      return true;
+    } catch (error) {
+      this.logger.error('Redis health check failed:', error);
+      return false;
+    }
+  }
+
+ 
+  private async initializeClient() {
+    try {
+      this.client = createClient({
+        url: this.config.getConectionURL(),
+        socket: {
+          connectTimeout: 10000, // 10 secgundos
+          reconnectStrategy: (retries) => {
+            if (retries > this.MAX_RETRY_ATTEMPTS) {
+              this.logger.error(
+                `Maximum retry attempts (${this.MAX_RETRY_ATTEMPTS}) reached`,
+              );
+              return new Error('Maximum retry attempts reached');
+            }
+            const delay = Math.min(retries * 1000, 5000);
+            this.logger.info(`Retrying connection in ${delay}ms...`);
+            return delay;
+          },
+        },
+      });
+
+      
+      this.setupEventHandlers();
+      await this.client.connect();
+      this.logger.info('Redis client initialized successfully');
+    } catch (error) {
+      this.logger.error('Failed to initialize Redis client:', error);
+      if (this.retryCount < this.MAX_RETRY_ATTEMPTS) {
+        this.retryCount++;
+        this.logger.info(
+          `Retrying initialization (attempt ${this.retryCount}/${this.MAX_RETRY_ATTEMPTS})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        await this.initializeClient();
+      } else {
+        throw new Error(
+          `Failed to initialize Redis client after ${this.MAX_RETRY_ATTEMPTS} attempts`,
+        );
+      }
+    }
+  }
+
+
+  private setupEventHandlers() {
+    this.client.on('error', (err) => {
+      this.logger.error('Redis Client Error:', err);
+    });
+
+    this.client.on('connect', () => {
+      this.logger.info('Redis Client Connected Successfully');
+      this.retryCount = 0; 
+    });
+
+    this.client.on('reconnecting', () => {
+      this.logger.warn('Redis Client Reconnecting...');
+    });
+
+    this.client.on('end', () => {
+      this.logger.info('Redis Client Connection Closed');
+    });
+
+    process.on('SIGINT', async () => {
+      await this.onModuleDestroy();
+      process.exit(0);
+    });
   }
 }

--- a/src/cache-handler/clients/redisClient.ts
+++ b/src/cache-handler/clients/redisClient.ts
@@ -71,6 +71,8 @@ export class RedisClientService implements OnModuleInit, OnModuleDestroy {
     try {
       this.client = createClient({
         url: this.config.getConectionURL(),
+        password: this.config.password,
+        database: this.config.database,
         socket: {
           connectTimeout: 10000, // 10 secgundos
           reconnectStrategy: (retries) => {

--- a/src/cache-handler/config/redis.config.ts
+++ b/src/cache-handler/config/redis.config.ts
@@ -3,12 +3,13 @@ import { RedisConfiguration } from '../interfaces/cache-hander.interface';
 export class RedisConfig implements RedisConfiguration {
   constructor(
     public host: string,
-    public port: number,
+    public port: number = 6379,
     public password?: string,
     public database?: number,
   ) {}
 
   getConectionURL(): string {
+
     return `redis://${this.host}:${this.port}`;
   }
 }

--- a/src/health/disk.health.ts
+++ b/src/health/disk.health.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
+import * as diskusage from 'diskusage';
+
+@Injectable()
+export class DiskHealthIndicator extends HealthIndicator {
+  private readonly DISK_SPACE_THRESHOLD = 1024 * 1024 * 1024; // 1GB
+
+  async checkHealth(key: string): Promise<HealthIndicatorResult> {
+    try {
+      const { available, total } = diskusage.checkSync('/');
+      const avaliableMB = Math.round(available / 1024 / 1024);
+      const totalMB = Math.round(total / 1024 / 1024);
+
+      const isHealthy = available > this.DISK_SPACE_THRESHOLD;
+
+      return this.getStatus(key, isHealthy, {
+        available: `${avaliableMB} MB`,
+        total: `${totalMB} MB`,
+      });
+    } catch (error) {
+      return this.getStatus(key, false, {
+        message: error.message,
+      });
+    }
+  }
+}

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -4,6 +4,7 @@ import { LoggerService } from 'src/logger/logger.service';
 import { Controller, Get } from '@nestjs/common';
 import { PostgresHealthIndicator } from './postgres.health';
 import {MemoryHealthIndicator} from './memory.health';
+import {DiskHealthIndicator} from './disk.health';
 
 @Controller('health')
 export class HealthController {
@@ -13,6 +14,7 @@ export class HealthController {
     private postgres: PostgresHealthIndicator,
     private logger: LoggerService,
     private memory: MemoryHealthIndicator,
+    private disk: DiskHealthIndicator,
   ) {}
 
   @Get()
@@ -23,13 +25,14 @@ export class HealthController {
         () => this.redis.checkHealth('redis'),
         () => this.postgres.checkHealth('postgres'),
         () => this.memory.checkHealth('memory'),
+        () => this.disk.checkHealth('disk'),
       ]);
 
       this.logger.getLogger().info('Health check complete successfully');
       return this.formatHealthCheckResult(result);
     } catch (error) {
       this.logger.getLogger().error('Health check failed', error);
-      throw error;
+      return this.formatHealthCheckResult(error.response);
     }
   }
 
@@ -107,4 +110,21 @@ export class HealthController {
       return this.formatHealthCheckResult(error.response);
     }
   }
+
+  @Get('disk')
+  @HealthCheck()
+  async checkDisk() {
+    try {
+      const result = await this.health.check([
+        () => this.disk.checkHealth('disk'),  // Verifica la salud del disco
+      ]);
+      this.logger.getLogger().info('Disk health check complete successfully');
+      return this.formatHealthCheckResult(result);
+    } catch (error) {
+      this.logger.getLogger().error('Disk health check failed', error);
+      return this.formatHealthCheckResult(error.response);
+    }
+  }
+
+
 }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,110 @@
+import { HealthCheck, HealthCheckService } from '@nestjs/terminus';
+import { RedisHealthIndicator } from './redis.health';
+import { LoggerService } from 'src/logger/logger.service';
+import { Controller, Get } from '@nestjs/common';
+import { PostgresHealthIndicator } from './postgres.health';
+import {MemoryHealthIndicator} from './memory.health';
+
+@Controller('health')
+export class HealthController {
+  constructor(
+    private health: HealthCheckService,
+    private redis: RedisHealthIndicator,
+    private postgres: PostgresHealthIndicator,
+    private logger: LoggerService,
+    private memory: MemoryHealthIndicator,
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  async check() {
+    try {
+      const result = await this.health.check([
+        () => this.redis.checkHealth('redis'),
+        () => this.postgres.checkHealth('postgres'),
+        () => this.memory.checkHealth('memory'),
+      ]);
+
+      this.logger.getLogger().info('Health check complete successfully');
+      return this.formatHealthCheckResult(result);
+    } catch (error) {
+      this.logger.getLogger().error('Health check failed', error);
+      throw error;
+    }
+  }
+
+  private formatHealthCheckResult(result: any) {
+    const formattedResult: any = { status: result.status, services: [] };
+
+    // Manejar servicios saludables
+    if (result.info) {
+      for (const [key, details] of Object.entries(result.info)) {
+        formattedResult.services.push({
+          name: key,
+          status: 'up',
+          ...(typeof details === 'object' && details !== null ? details : {}),
+        });
+      }
+    }
+
+    // Manejar servicios con errores
+    if (result.error) {
+      for (const [key, details] of Object.entries(result.error)) {
+        formattedResult.services.push({
+          name: key,
+          status: 'down',
+          ...(typeof details === 'object' && details !== null ? details : {}),
+        });
+      }
+    }
+
+    return formattedResult;
+  }
+
+  @Get('redis')
+  @HealthCheck()
+  async checkRedis() {
+    try {
+      const result = await this.health.check([
+        () => this.redis.checkHealth('redis'),
+      ]);
+      this.logger.getLogger().info('Redis health check complete successfully');
+      return this.formatHealthCheckResult(result);
+    } catch (error) {
+      this.logger.getLogger().error('Health check failed', error);
+      return this.formatHealthCheckResult(error.response);
+    }
+  }
+
+  @Get('postgres')
+  @HealthCheck()
+  async checkPostgres() {
+    try {
+      const result = await this.health.check([
+        () => this.postgres.checkHealth('postgres'),
+      ]);
+      this.logger
+        .getLogger()
+        .info('Postgres health check complete successfully');
+      return this.formatHealthCheckResult(result);
+    } catch (error) {
+      this.logger.getLogger().error('Health check failed', error);
+      return this.formatHealthCheckResult(error.response);
+    }
+  }
+
+  @Get('memory')
+  @HealthCheck()
+  async checkMemory() {
+    try {
+      const result = await this.health.check([
+        () => this.memory.checkHealth('memory'),  // Verifica la salud de la memoria
+      ]);
+      this.logger.getLogger().info('Memory health check complete successfully');
+      return this.formatHealthCheckResult(result);
+    } catch (error) {
+      this.logger.getLogger().error('Memory health check failed', error);
+      return this.formatHealthCheckResult(error.response);
+    }
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -6,6 +6,7 @@ import {LoggingModule} from 'src/logger/logger.module';
 import {RedisHealthIndicator} from './redis.health';
 import {PostgresHealthIndicator} from './postgres.health';
 import {MemoryHealthIndicator} from './memory.health';
+import {DiskHealthIndicator} from './disk.health';
 
 @Module({
   imports:[
@@ -17,7 +18,8 @@ import {MemoryHealthIndicator} from './memory.health';
   providers: [
     RedisHealthIndicator,
     PostgresHealthIndicator,
-    MemoryHealthIndicator
+    MemoryHealthIndicator,
+    DiskHealthIndicator
   ],
 })
 export class HealthModule {}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import {TerminusModule} from '@nestjs/terminus';
+import {RedisModule} from 'src/cache-handler/cache-handler.module';
+import {LoggingModule} from 'src/logger/logger.module';
+import {RedisHealthIndicator} from './redis.health';
+import {PostgresHealthIndicator} from './postgres.health';
+import {MemoryHealthIndicator} from './memory.health';
+
+@Module({
+  imports:[
+    TerminusModule,
+    RedisModule,
+    LoggingModule
+  ],
+  controllers: [HealthController],
+  providers: [
+    RedisHealthIndicator,
+    PostgresHealthIndicator,
+    MemoryHealthIndicator
+  ],
+})
+export class HealthModule {}

--- a/src/health/memory.health.ts
+++ b/src/health/memory.health.ts
@@ -3,7 +3,7 @@ import { HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
 
 @Injectable()
 export class MemoryHealthIndicator extends HealthIndicator {
-  private readonly MEMORY_LIMIT_MB = 80;  
+  private readonly MEMORY_LIMIT_MB = 500;  
 
   async checkHealth(key: string): Promise<HealthIndicatorResult> {
     const memory = process.memoryUsage();

--- a/src/health/memory.health.ts
+++ b/src/health/memory.health.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult } from '@nestjs/terminus';
+
+@Injectable()
+export class MemoryHealthIndicator extends HealthIndicator {
+  private readonly MEMORY_LIMIT_MB = 80;  
+
+  async checkHealth(key: string): Promise<HealthIndicatorResult> {
+    const memory = process.memoryUsage();
+    const memoryUsageInMB = Math.round(memory.rss / 1024 / 1024);
+
+    const isHealthy = memoryUsageInMB <= this.MEMORY_LIMIT_MB;
+
+    const formatMemory = {
+      memory: `${memoryUsageInMB} MB`,
+    };
+
+    if (!isHealthy) {
+      return this.getStatus(key, false, {
+        ...formatMemory,
+        message: `Memoria excede el límite de ${this.MEMORY_LIMIT_MB} MB`,
+      });
+    }
+
+    return this.getStatus(key, true, formatMemory);
+  }
+}

--- a/src/health/postgres.health.ts
+++ b/src/health/postgres.health.ts
@@ -1,0 +1,32 @@
+// health/postgres.health.ts
+import { Injectable } from '@nestjs/common';
+import { HealthIndicator, HealthIndicatorResult, HealthCheckError } from '@nestjs/terminus';
+import {Connection} from 'mysql2/typings/mysql/lib/Connection';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class PostgresHealthIndicator extends HealthIndicator {
+  constructor(private dataSource: DataSource) {
+    super();
+  }
+
+  async checkHealth(key: string): Promise<HealthIndicatorResult> {
+    try {
+
+      await this.dataSource.query('SELECT 1');
+      return this.getStatus(key, true, {
+        host: process.env.POSTGRES_HOST,
+        port: process.env.POSTGRES_PORT,
+        database: process.env.POSTGRES_DATABASE,
+      });
+    } catch (error) {
+      const result = this.getStatus(key, false, {
+        host: process.env.POSTGRES_HOST,
+        port: process.env.POSTGRES_PORT,
+        database: process.env.POSTGRES_DATABASE,
+        error: error.message,
+      });
+      throw new HealthCheckError('Postgres check failed', result);
+    }
+  }
+}

--- a/src/health/redis.health.ts
+++ b/src/health/redis.health.ts
@@ -1,0 +1,41 @@
+import {Injectable} from "@nestjs/common";
+import {HealthCheckError, HealthIndicator, HealthIndicatorResult} from "@nestjs/terminus";
+import {RedisClientService} from "src/cache-handler/clients/redisClient";
+import {LoggerService} from "src/logger/logger.service";
+
+@Injectable()
+export class RedisHealthIndicator extends HealthIndicator {
+  constructor(
+    private redisService: RedisClientService,
+    private logger: LoggerService
+    ) {
+    super();
+  }
+
+  async checkHealth(key: string): Promise<HealthIndicatorResult> {
+    try {
+      const isHealthy = await this.redisService.isHealthy();
+      const result = this.getStatus(key, isHealthy, {
+        host: process.env.REDIS_HOST,
+        port: process.env.REDIS_PORT,
+        database: process.env.REDIS_DATABASE,
+      });
+
+      if (!isHealthy) {
+        throw new HealthCheckError(
+          'Redis check failed',
+          result
+        );
+      }
+
+      return result;
+    } catch (error) {
+      return this.getStatus(key, false, {
+        error: error.message,
+        host: process.env.REDIS_HOST,
+        port: process.env.REDIS_PORT,
+        database: process.env.REDIS_DATABASE,
+      });
+    }
+  }
+}


### PR DESCRIPTION
Este PR introduce un nuevo módulo llamado HealthChecker diseñado para monitorear el estado de los servicios en producción. El módulo incluye la verificación del estado de los siguientes servicios:

-     Redis: Comprueba la conectividad y el estado del servicio Redis configurado en el servidor.
-     Postgres: Verifica la conexión con la base de datos PostgreSQL, incluyendo detalles como el host, puerto y nombre de la base de datos.
-     Consumo de Memoria: Monitorea el uso de memoria del servidor, alertando si el consumo supera un límite predefinido (por defecto, 500 MB).
-     Consumo de Disco: Mide el espacio libre en disco, proporcionando alertas en caso de que el espacio disponible sea insuficiente.
- 

Cambios Incluidos

    Creación de indicadores personalizados para cada servicio:

-         RedisHealthIndicator
-         PostgresHealthIndicator
-         MemoryHealthIndicator
-         DiskHealthIndicator

    Implementación del controlador HealthController para exponer endpoints de monitoreo:

-         GET /health: Retorna el estado general de todos los servicios.
-         GET /health/redis: Verifica únicamente el estado de Redis.
-         GET /health/postgres: Verifica únicamente el estado de Postgres.
-         GET /health/memory: Verifica el consumo de memoria.
-         GET /health/disk: Verifica el espacio en disco.
   Agregada lógica para formatear la respuesta de los endpoints:

        Las respuestas indican si cada servicio está up (funcionando correctamente) o down (con problemas).
        En caso de errores, se incluyen detalles específicos (e.g., mensajes de error o métricas relevantes).

Motivación

Este módulo tiene como objetivo proporcionar un sistema de monitoreo centralizado para asegurar que los servicios críticos del sistema estén funcionando correctamente. Permite a los equipos de operaciones y desarrollo identificar problemas en tiempo real, mejorando la confiabilidad y la estabilidad del sistema en producción.

Cómo Probar

-     Desplegar la rama en un entorno de prueba o local.
-     Asegurarse de que los servicios de Redis y Postgres estén configurados correctamente.
-     Probar los endpoints individuales (/health/redis, /health/postgres, etc.) y el endpoint general (/health).
-     Simular fallos en los servicios (e.g., detener Redis o exceder el límite de memoria) y validar que los errores se reflejen correctamente en la respuesta del endpoint.

Consideraciones

    Requiere las siguientes variables de entorno configuradas:
        POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DATABASE
        REDIS_HOST, REDIS_PORT
    Se incluyó un límite por defecto para la memoria en el indicador MemoryHealthIndicator (500 MB). Este valor puede ajustarse según las necesidades del entorno.